### PR TITLE
Fix "carbon neutral" banner position and wrapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,17 +14,17 @@
       <a class="head__link" href="">About Us</a>
       <a class="head__link" href="">Google Store</a>
     </div>
-      <nav class="head__nav">
-        <a class="head__link" href="">Gmail</a>
-        <a class="head__link" href="">Images</a>
-        <!-- title will be replaced with a css tooltip later on -->
-        <nav class="material-icons-sharp head__apps" title="Google Apps">apps</nav>
-        <button class="btn btn--primary head__btn">Sign in</button>
-      </nav>
+    <nav class="head__nav">
+      <a class="head__link" href="">Gmail</a>
+      <a class="head__link" href="">Images</a>
+      <!-- title will be replaced with a css tooltip later on -->
+      <nav class="material-icons-sharp head__apps" title="Google Apps">apps</nav>
+      <button class="btn btn--primary head__btn">Sign in</button>
+    </nav>
   </header>
 
   <main>
-      <img src="https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png" height="92px" width="272px" alt="Google">
+    <img src="https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png" height="92px" width="272px" alt="Google">
     <!-- ??? does this not need the alt since its a logo or does it need it since its the main image of the page?-->
     <form action="" class="search">
       <div class="search__bar">
@@ -49,15 +49,17 @@
     <!-- ??? is there a geographic location HTML element? seaching returns olny JS geolocation stuff so im assuming its something i will encounter later on -->
     <div class="location">Italy</div>
     <nav class="foot__nav">
-      <div>
+      <nav class="foot__nav--business" >
         <a class="foot__a" href="">Advertising</a>
         <a class="foot__a" href="">Business</a>
         <a class="foot__a" href="">How Search Works</a>
+      </nav>
+      <div class="foot__eco">
+        <a class="foot__a" href="">
+          <!-- ! KEEP AS ONE LINE to avoid underline on new line character -->
+          <img class="foot__eco--img" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABUAAAAYCAMAAAAiV0Z6AAAAPFBMVEVLoEN0wU6CzFKCzFKCzFKCzFKCzFJSo0MSczNDmkCCzFJPoUMTczNdr0gmgziCzFITczMTczMTczMTczPh00jOAAAAFHRSTlPF/+bIsms8Ad///hX+//5/tXw7aMEAx10AAACaSURBVHgBbc4HDoRQCATQ33tbvf9dF9QxaCT9UQaltLHOh/golXKhMs5Xqa0xU1lyoa2fXFyQOsDG38qsLy4TaV+sFislovyhPzLJJrBu6eQOtpW0LjbJkzTuTDLRVNKa3uxJI+VdiRqXSeu6GW+Qxi29eLIi8H7EsYrT42BD+mQtNO5JMjRuC4lSY8V4hsLX0egGijvUSEP9AbylEsOkeCgWAAAAAElFTkSuQmCC" alt=""><span class="foot__eco--text">Carbon neutral since 2007</span></a>
       </div>
-      <!-- ! KEEP AS ON LINE ! to avoid underline on new line character -->
-      <a class="foot__a foot_eco" href=""><img class="foot_eco--img" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABUAAAAYCAMAAAAiV0Z6AAAAPFBMVEVLoEN0wU6CzFKCzFKCzFKCzFKCzFJSo0MSczNDmkCCzFJPoUMTczNdr0gmgziCzFITczMTczMTczMTczPh00jOAAAAFHRSTlPF/+bIsms8Ad///hX+//5/tXw7aMEAx10AAACaSURBVHgBbc4HDoRQCATQ33tbvf9dF9QxaCT9UQaltLHOh/golXKhMs5Xqa0xU1lyoa2fXFyQOsDG38qsLy4TaV+sFislovyhPzLJJrBu6eQOtpW0LjbJkzTuTDLRVNKa3uxJI+VdiRqXSeu6GW+Qxi29eLIi8H7EsYrT42BD+mQtNO5JMjRuC4lSY8V4hsLX0egGijvUSEP9AbylEsOkeCgWAAAAAElFTkSuQmCC" alt=""><span class="foot__eco--text">Carbon neutral since 2007</span>
-      </a>
-      <div>
+      <div class="foot__nav--legal" lab>
         <a class="foot__a" href="">Privacy</a>
         <a class="foot__a" href="">Terms</a>
         <a class="foot__a" href="">Settings</a>

--- a/styles/style.css
+++ b/styles/style.css
@@ -4,7 +4,6 @@ body, html {
   margin: 0px;
   padding: 0px;
   border: none;
-  box-sizing: border-box;
   /* font */
   font-style: normal;
   font-variant: normal;
@@ -163,12 +162,18 @@ footer {
   background-color: lightgrey;
   background-color: var(--clr-darker-10);
 }
+
+.location {
+  padding: 1em 2em;
+  border-bottom: 1px solid var(--clr-darker-10);
+}
+
 .foot__nav {
   display: flex;
   flex-flow: row wrap;
-  justify-content: space-between;
   align-items: center;
-  padding: 0 1.5em;
+  margin: 0px 1rem;
+  justify-content: space-between;
 }
 
 .foot__a {
@@ -176,30 +181,49 @@ footer {
   color: inherit;
   text-decoration: none;
   padding: 1em;
+  display: block;
+  white-space: nowrap;
+  text-align: center;
 }
 .foot__a:hover {
   text-decoration: underline;
 }
 
-.foot__eco {
+.foot__nav--business, .foot__nav--legal {
+  /* set as the widest of the row in rem*/
+  min-width: 22rem;
   display: flex;
   flex-flow: row nowrap;
-  align-items: baseline;
-  justify-content: center;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.foot__nav--legal{
+  justify-content: flex-end;
+}
+
+.foot__eco {
+  margin: 0 auto;
 }
 
 .foot__eco--img{
-height: 100%;
-width: auto;
+  height: 1em;
+  width: auto;
+  margin-right: 1ch;
 }
 
-.foot__eco--text {
-  margin-left: 1ch;
-}
-
-.location {
-  padding: 1em 2em;
-  border-bottom: 1px solid var(--clr-darker-10);
+/* max-width is widest times number of elements */
+@media screen and (max-width: 66rem) {
+  .foot__eco {
+    order: -1;
+    width: 100vw;
+  }
+  .foot__nav--legal, .foot__nav--business {
+    min-width: max-content;
+  }
+  .foot__nav {
+    justify-content: space-around;
+  }
 }
 
 .btn--primary {


### PR DESCRIPTION
Centering:
Sets the min-width of the other siblings in the footer to a width in
rem units thats >= of the largest of the 3, this leaves a now centered
space in the middle where foot__eco itself can be centered with
margin: 0 auto;

Wrapping:
The media query max-width value is set to the value of min-width chosen
for the Centering multiplied for the number of elements, this ensures
that the flex container will never wrap before the media query is
active. Then the foot__eco is given a flex order lower than its sibling
and a width of 100vh to force a wrap that puts it on top of them.