### PR TITLE
Fix issue #4

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,9 @@
         <!-- cant find colored icon from google licensed sites -->
         <!-- title will be replaced with a css tooltip later on -->
         <!-- I am assuming this button does "stuff" in the overlay it shows, and the result of that "stuff" gets pasted into the input and submitted-->
-        <button class="material-icons-sharp search__bar--icon btn btn--voice-search" title="Search by voice">mic</button>
+        <button class="search__bar--icon btn m-voice-search" title="Search by voice">
+         <span class="material-icons-sharp">mic</span>
+        </button>
       </div>
       <div class="search__btn--row">
         <button class="btn"> Google Search</button>


### PR DESCRIPTION
Fixes #4

The font family in the icons class was being overwritten by the one for
the buttons. To ensure the modularity of the CSS instead of directly
adding the icons to the elements where they are needed and applying the
class to that element, it's better to put them in a nested <span> that
has only that class. This ensures both that the icons are shown
properly and that any other text is not accidentally converted to an
icon. It also allows to apply other CSS to only the icons without
effecting the parent element.

The parent element also had a class that was prematurely renamed
and moved in the header rebase (merge #3) and caused the voice search
to display as a regular button.