### PR TITLE
Add a workaround for issue #5

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="styles/style.css">
 </head>
 
-<body>
+<body class="">
   <header class="l-flex-row">
     <nav class="l-flex-row">
       <a class="h-margin-orizontal h-text-wrap h-text-no-decoration" href="">About Us</a>
@@ -27,11 +27,13 @@
     </nav>
   </header>
 
-  <main class="l-flex-col">
-    <img src="https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png" height="92px" width="272px" alt="Google">
+  <main>
+    <div class="l-flex-col m-logo">
+      <img src="https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png" height="92px" width="272px" alt="Google">
+    </div>
     <!-- ??? does this not need the alt since its a logo or does it need it since its the main image of the page?-->
     <form action="" class="l-flex-col">
-      <div class="l-flex-row m-searchbar">
+      <div class="l-flex-row m-searchbar h-margin-vertical">
         <!-- ??? Does this spell out "search" on a screen reader? Should I get a screen reader for testing or is the chrome accessibility lightouse test in the devs tool enough? -->
         <label for="google-search" class="m-search-icon" >
           <span class="material-icons-sharp">search</span>
@@ -50,8 +52,10 @@
         <button class="m-btn"> I'm Feeling Lucky</button>
       </div>
     </form>
-    <!-- only show if locale != lang -->
-    <span class="m-conditionals">Google offered in: <a href="">Italiano</a></span>
+    <div class="l-flex-col m-contitionals">
+      <!-- only show if locale != lang -->
+      <span class="h-margin-vertical">Google offered in: <a href="">Italiano</a></span>
+    </div>
   </main>
 
   <footer>

--- a/styles/style.css
+++ b/styles/style.css
@@ -23,6 +23,11 @@ header {
   white-space: normal;
 }
 
+main{
+  height: 100%;
+  padding-bottom: 1rem;
+}
+
 footer {
   font-size: small;
   color: rgba(0, 0, 0, 0.6);
@@ -77,7 +82,6 @@ footer {
 }
 
 .m-searchbar {
-  margin: 1rem 0;
   padding: 0 1rem;
   max-width: 87vw;
   background-color: rgba(255, 255, 255, 0.75);
@@ -102,8 +106,16 @@ footer {
   outline: none;
 }
 
+.m-logo {
+  justify-content: flex-end;
+  min-height: 92px;
+  max-height: 290px;
+  height: 35%;
+  /* height: calc(100% - 560px); */
+  flex: 0 0 auto;
+}
 .m-conditionals {
-  margin: 1rem;
+  flex: 1 0 auto;
 }
 
 .m-location {
@@ -113,7 +125,7 @@ footer {
 }
 
 .m-sub-nav {
-  margin: 0 1rem;
+  padding: 0 1rem;
 }
 
 .m-sub-nav__left,
@@ -147,6 +159,10 @@ footer {
 
 .h-margin-orizontal{
   margin: 0 0.5rem;
+}
+
+.h-margin-vertical{
+  margin: 1rem 0;
 }
 
 .h-text-wrap{


### PR DESCRIPTION
styles/style.css Lines 113-114

Line 113 leaves the main section close to  where it should be for the
most popular desktop screen sizes.

Line 114 is the value from the original google.com homepage, when is
used the behavior is closer to the original but the main section sits
too high on the page.